### PR TITLE
Pre-normalized IceSserver objects are passed through.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ module.exports = function(input) {
   url = url.slice(5);
   parts = url.split('@');
 
+  output.username = input.username;
+  output.credential = input.credential;
   // if we have an authentication part, then set the credentials
   if (parts.length > 1) {
     url = parts[1];

--- a/test/data/servers-url.js
+++ b/test/data/servers-url.js
@@ -6,5 +6,6 @@ exports.turn = [
   { url: 'turn:tmp:test@example.org:3478' },
   { url: 'turn:tmp@example.org:3478', credential: 'test' },
   { url: 'turn:tmp@example.org', credential: 'test' },
-  { url: 'turn:tmp@example.org?transport=tcp', credential: 'test' }
+  { url: 'turn:tmp@example.org?transport=tcp', credential: 'test' },
+  { url: 'turn:example.org?transport=tcp', username: 'tmp', credential: 'test' }
 ];

--- a/test/turn.js
+++ b/test/turn.js
@@ -50,3 +50,15 @@ function runTests(servers) {
   });
 }
 
+test('normalizing an already normalized turn url object', function (t) {
+  var serverObjs = require('./data/servers-url');
+  var server;
+
+  t.plan(5);
+  t.ok(server = normalice(serverObjs.turn[4]));
+  t.equal(server.url, 'turn:example.org?transport=tcp');
+  t.deepEqual(server.urls, ['turn:example.org?transport=tcp']);
+  t.equal(server.username, 'tmp');
+  t.equal(server.credential, 'test');
+});
+


### PR DESCRIPTION
In the event that an already normalized object is given to the module,
it should return the object as is.

One example case of this is any application using XirSys for STUN/TURN
servers, where you get back an array of already valid IceServer objects.
These, when passed to rtc-io's quickconnect, were getting their
credentials and usernames removed.
